### PR TITLE
Add Jackson Datatype JSR310

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -12,6 +12,10 @@
 
     <artifactId>mercuryit-json</artifactId>
 
+    <properties>
+        <version.jackson>2.15.2</version.jackson>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>community.redrover.mercuryit</groupId>
@@ -22,13 +26,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>${version.jackson}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.2</version>
+            <version>${version.jackson}</version>
         </dependency>
     </dependencies>
 </project>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -24,5 +24,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.15.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/json/src/main/java/community/redrover/mercuryit/MercuryITJsonConfig.java
+++ b/json/src/main/java/community/redrover/mercuryit/MercuryITJsonConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.*;
 
 import java.util.Map;
@@ -19,6 +20,7 @@ public class MercuryITJsonConfig extends MercuryITConfig {
         private final ObjectMapper objectMapper = JsonMapper.builder()
                     .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .addModule(new JavaTimeModule())
                     .build();
 
         public <T> T fromMap(Map<String, Object> map, Class<T> clazz) {


### PR DESCRIPTION
Jackson JSR-310 Module is an extension module for the Jackson library, which is a popular JSON serialization and deserialization library for Java. 
The JSR-310 Module specifically focuses on integrating the Java Date and Time API, also known as JSR-310, with Jackson.